### PR TITLE
feat: Added generatePackageTree 

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import meow from 'meow';
 import pify from 'pify';
 
 import {outputToUser} from './output';
-import {generatePackageTree} from './package-tree';
+import {generatePackageTree, populatePOIInPackageTree, resolvePaths} from './package-tree';
 
 const cli = meow({
   help: `  
@@ -57,8 +57,12 @@ async function run(packageRootDir: string) {
   const pJson = await pify(fs.readFile)('package.json');
 
   // Step 3: create package tree - generatePackageTree or main function
-  const packageTree = generatePackageTree(pJson);
+  const emptyPackageTree = await generatePackageTree(pJson);
+  const packageTreeWithPath = await resolvePaths(emptyPackageTree, '.');
+  const packageTreeWithPOI =
+      await populatePOIInPackageTree(packageTreeWithPath);
 
   // Step 4: output
-  outputToUser(packageTree);
+  // TODO: Uncomment this line.
+  outputToUser(packageTreeWithPOI);
 }

--- a/src/package-tree.ts
+++ b/src/package-tree.ts
@@ -1,9 +1,10 @@
 
-import {getDynamicEval, getIOModules} from './analysis';
-import {fileInfo, filesInDir, readFile} from './util';
 import * as fs from 'fs';
 import * as path from 'path';
 import pify from 'pify';
+
+import {getDynamicEval, getIOModules} from './analysis';
+import {fileInfo, filesInDir, readFile} from './util';
 
 export const readFilep = pify(fs.readFile);
 
@@ -39,33 +40,33 @@ export async function generatePackageTree(
     customReadFilep?: ReadFileP): Promise<PackageTree<undefined>> {
   customReadFilep = customReadFilep || readFilep;
 
-    // Step 0: read in package.json and package-lock.json
-    const pjsonPath = path.join(rootDir, 'package.json');
-    const pjson = await customReadFilep(pjsonPath, 'utf8');
-    const packageJson = JSON.parse(pjson);
+  // Step 0: read in package.json and package-lock.json
+  const pjsonPath = path.join(rootDir, 'package.json');
+  const pjson = await customReadFilep(pjsonPath, 'utf8');
+  const packageJson = JSON.parse(pjson);
 
-    const pjsonLockPath = path.join(rootDir, 'package-lock.json');
-    const pjsonLock = await customReadFilep(pjsonLockPath, 'utf8');
-    const packageLockJson = JSON.parse(pjsonLock);
+  const pjsonLockPath = path.join(rootDir, 'package-lock.json');
+  const pjsonLock = await customReadFilep(pjsonLockPath, 'utf8');
+  const packageLockJson = JSON.parse(pjsonLock);
 
-    // Step 1: Get the top level dependencies from pjson
-    const dependencies = {
-      ...packageJson.dependencies,
-      ...packageJson.devDependencies
-    };
+  // Step 1: Get the top level dependencies from pjson
+  const dependencies = {
+    ...packageJson.dependencies,
+    ...packageJson.devDependencies
+  };
 
-    // Step 2: Look at package-lock.json to find dependendencies
-    const result =
-        await getPackageTreeFromDependencyList(dependencies, packageLockJson);
+  // Step 2: Look at package-lock.json to find dependendencies
+  const result =
+      await getPackageTreeFromDependencyList(dependencies, packageLockJson);
 
-    const treeHead: PackageTree<undefined> = {
-      name: packageJson.name,
-      version: packageJson.version,
-      data: undefined,
-      dependencies: result
-    }
+  const treeHead: PackageTree<undefined> = {
+    name: packageJson.name,
+    version: packageJson.version,
+    data: undefined,
+    dependencies: result
+  };
 
-    return treeHead;
+  return treeHead;
 }
 
 /**

--- a/src/package-tree.ts
+++ b/src/package-tree.ts
@@ -25,7 +25,7 @@ export interface Position {
   colEnd: number;
 }
 
-export interface PackageTree<T> {
+export interface PackageTree<T = null> {
   name: string;
   version: string;
   data: T;
@@ -36,8 +36,7 @@ export interface PackageTree<T> {
  * Takes in the root directory of a project and returns returns a PackageTree
  */
 export async function generatePackageTree(
-    rootDir: string,
-    customReadFilep?: ReadFileP): Promise<PackageTree<undefined>> {
+    rootDir: string, customReadFilep?: ReadFileP): Promise<PackageTree> {
   customReadFilep = customReadFilep || readFilep;
 
   // Step 0: read in package.json and package-lock.json
@@ -59,10 +58,10 @@ export async function generatePackageTree(
   const result =
       await getPackageTreeFromDependencyList(dependencies, packageLockJson);
 
-  const treeHead: PackageTree<undefined> = {
+  const treeHead: PackageTree = {
     name: packageJson.name,
     version: packageJson.version,
-    data: undefined,
+    data: null,
     dependencies: result
   };
 
@@ -129,8 +128,7 @@ export async function getPackagePOIList(path: string):
  * @param rootPath the path to the root node
  */
 export async function resolvePaths(
-    rootNode: PackageTree<null>,
-    rootPath: string): Promise<PackageTree<string>> {
+    rootNode: PackageTree, rootPath: string): Promise<PackageTree<string>> {
   const updatedNodesMap = new Map<string, PackageTree<string>>();
   const resolvedNodes: Array<PackageTree<string>> = [];
 
@@ -150,7 +148,7 @@ export async function resolvePaths(
   return updatedRoot;
 
   async function resolvePathsRec(
-      packageNode: PackageTree<null>, parentPath: string,
+      packageNode: PackageTree, parentPath: string,
       updatedNodesMap: Map<string, PackageTree<string>>):
       Promise<PackageTree<string>> {
     const paths: string[] = [];
@@ -225,22 +223,12 @@ function getPointsOfInterest(
   return pointsOfInterest;
 }
 
-function main() {
-  // TODO:
-  // const emptyPackageTree: PackageTree<null> = (TODO: function that creates
-  //                                            package tree with data as null)
-  // const packageTreeWithPath = resolvePaths(emptyPackageTree, <CLI INPUT>);
-  // const packageTreeWithPOI = populatePOIInPackageTree(packageTreeWithPath);
-  throw new Error('not implemented');
-}
-
 /**
  * Takes in a list of depndencies and returns a constructed PackageTree
  * @param packageLockJson the package-lock.json file of the root project
  */
 export async function getPackageTreeFromDependencyList(
-    dependencies: {},
-    packageLockJson: {}): Promise<Array<PackageTree<undefined>>> {
+    dependencies: {}, packageLockJson: {}): Promise<PackageTree[]> {
   // Step 1: For each dependency create a PackageTree obj with the name and
   // version fields populated
   if (!dependencies) {
@@ -248,15 +236,11 @@ export async function getPackageTreeFromDependencyList(
   }
 
   const dependencyArr: Array<[string, string]> = Object.entries(dependencies);
-  const packageTreeArr: Array<PackageTree<undefined>> = [];
+  const packageTreeArr: PackageTree[] = [];
 
   dependencyArr.forEach((element: [string, string]) => {
-    const pkgTreeObj: PackageTree<undefined> = {
-      name: element[0],
-      version: element[1],
-      data: undefined,
-      dependencies: []
-    };
+    const pkgTreeObj: PackageTree =
+        {name: element[0], version: element[1], data: null, dependencies: []};
 
     packageTreeArr.push(pkgTreeObj);
   });
@@ -274,9 +258,9 @@ export async function getPackageTreeFromDependencyList(
  * package-lock.json have not been written yet
  */
 async function populateDependencies(
-    pkg: PackageTree<undefined>,
+    pkg: PackageTree,
     // tslint:disable-next-line:no-any
-    packageLockJson: any): Promise<Array<PackageTree<undefined>>> {
+    packageLockJson: any): Promise<PackageTree[]> {
   const packageName = pkg.name;
   const dependencies = packageLockJson.dependencies[packageName].requires;
   if (!dependencies) {
@@ -286,7 +270,7 @@ async function populateDependencies(
   return await getPackageTreeFromDependencyList(dependencies, packageLockJson);
 }
 
-function compare(a: PackageTree<undefined>, b: PackageTree<undefined>): number {
+function compare(a: PackageTree, b: PackageTree): number {
   if (a.name < b.name) {
     return -1;
   }

--- a/src/package-tree.ts
+++ b/src/package-tree.ts
@@ -39,7 +39,6 @@ export async function generatePackageTree(
     customReadFilep?: ReadFileP): Promise<PackageTree<undefined>> {
   customReadFilep = customReadFilep || readFilep;
 
-  try {
     // Step 0: read in package.json and package-lock.json
     const pjsonPath = path.join(rootDir, 'package.json');
     const pjson = await customReadFilep(pjsonPath, 'utf8');
@@ -64,12 +63,9 @@ export async function generatePackageTree(
       version: packageJson.version,
       data: undefined,
       dependencies: result
-    };
+    }
 
     return treeHead;
-  } catch (error) {
-    throw error;
-  }
 }
 
 /**

--- a/test/test-package-tree.ts
+++ b/test/test-package-tree.ts
@@ -11,7 +11,7 @@ import {generatePackageTree, getPackageTreeFromDependencyList, PackageTree} from
 import * as tests from './mock-projects';
 
 test(
-    'the data property of the package tree should changed from null ' +
+    'the data property of the package tree should changed from undefined ' +
         'to an array of Points of Interest',
     async t => {
       // See how the dependency graph looks in test-projects
@@ -22,7 +22,7 @@ test(
       const b1 = {name: 'b', version: '1.0.0', data: null, dependencies: [c1]};
       const a1 =
           {name: 'a', version: '1.0.0', data: null, dependencies: [b1, c1]};
-      const root =
+      const root: PackageTree =
           {name: 'root', version: '1.0.0', data: null, dependencies: [a1, c2]};
 
       const resolvedTree: PackageTree<string> =
@@ -92,11 +92,11 @@ test(
         {
           name: 'module1',
           version: 'version1',
-          data: undefined,
+          data: null,
           dependencies: [{
             name: 'module5',
             version: 'version5',
-            data: undefined,
+            data: null,
             dependencies: []
           }]
         },
@@ -104,11 +104,11 @@ test(
         {
           name: 'module2',
           version: 'version2',
-          data: undefined,
+          data: null,
           dependencies: [{
             name: 'module6',
             version: 'version6',
-            data: undefined,
+            data: null,
             dependencies: []
           }]
         }
@@ -150,16 +150,16 @@ test(
       const expectedResult = {
         name: 'testProject',
         version: '1.0.0',
-        data: undefined,
+        data: null,
         dependencies: [
           {
             name: 'module1',
             version: 'version1',
-            data: undefined,
+            data: null,
             dependencies: [{
               name: 'module5',
               version: 'version5',
-              data: undefined,
+              data: null,
               dependencies: []
             }]
           },
@@ -167,11 +167,11 @@ test(
           {
             name: 'module2',
             version: 'version2',
-            data: undefined,
+            data: null,
             dependencies: [{
               name: 'module6',
               version: 'version6',
-              data: undefined,
+              data: null,
               dependencies: []
             }]
           }

--- a/test/test-package-tree.ts
+++ b/test/test-package-tree.ts
@@ -6,7 +6,7 @@ import test from 'ava';
 import path from 'path';
 
 import * as tree from '../src/package-tree';
-import {PackageTree, generatePackageTree, getPackageTreeFromDependencyList} from '../src/package-tree';
+import {generatePackageTree, getPackageTreeFromDependencyList, PackageTree} from '../src/package-tree';
 
 import * as tests from './mock-projects';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "build"
+    "outDir": "build",
+    "lib": [
+      "es2017"
+    ]
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
generatePackageTree takes in a root directory of a package tree and returns a package tree with the project as the head and populated with its dependencies